### PR TITLE
ci: renovate extends bcgov/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,7 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Presets from https://github.com/bcgov/nr-renovate",
+  "extends": [
+    "github>bcgov/renovate-config"
+  ]
 }


### PR DESCRIPTION
Updated renovate.json. Extends from bcgov/renovate-config. Can be used with the Renovate GitHub app, which our upstream jobs are being replaced by.